### PR TITLE
Update tests to match new implementation

### DIFF
--- a/derive/common.t/run.t
+++ b/derive/common.t/run.t
@@ -35,7 +35,8 @@
     {
       tool_name = "ppx_driver";
       include_dirs = [];
-      load_path = [];
+      hidden_include_dirs = [];
+      load_path = ([], []);
       open_modules = [];
       for_package = None;
       debug = false;
@@ -52,16 +53,14 @@
   include
     struct
       let _ = fun (_ : numbers) -> ()
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let serialize_numbers =
-        let open Serde.Ser in fun t -> fun ctx -> (s (list int)) t ctx
+        let ( let* ) = Stdlib.Result.bind in
+        let _ = ( let* ) in
+        let open Serde.Ser in fun t ctx -> (s (list int)) t ctx
       let _ = serialize_numbers
       open! Serde
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let deserialize_numbers =
-        let ( let* ) = Result.bind in
+        let ( let* ) = Stdlib.Result.bind in
         let _ = ( let* ) in let open Serde.De in fun ctx -> (d (list int)) ctx
       let _ = deserialize_numbers
     end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -69,17 +68,15 @@
   include
     struct
       let _ = fun (_ : number_list_list) -> ()
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let serialize_number_list_list =
+        let ( let* ) = Stdlib.Result.bind in
+        let _ = ( let* ) in
         let open Serde.Ser in
-          fun t -> fun ctx -> (s (array (s serialize_numbers))) t ctx
+          fun t ctx -> (s (array (s serialize_numbers))) t ctx
       let _ = serialize_number_list_list
       open! Serde
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let deserialize_number_list_list =
-        let ( let* ) = Result.bind in
+        let ( let* ) = Stdlib.Result.bind in
         let _ = ( let* ) in
         let open Serde.De in fun ctx -> (d (array (d deserialize_numbers))) ctx
       let _ = deserialize_number_list_list

--- a/derive/records.t/run.t
+++ b/derive/records.t/run.t
@@ -79,7 +79,8 @@
     {
       tool_name = "ppx_driver";
       include_dirs = [];
-      load_path = [];
+      hidden_include_dirs = [];
+      load_path = ([], []);
       open_modules = [];
       for_package = None;
       debug = false;
@@ -98,25 +99,22 @@
   include
     struct
       let _ = fun (_ : rank) -> ()
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let serialize_rank =
+        let ( let* ) = Stdlib.Result.bind in
+        let _ = ( let* ) in
         let open Serde.Ser in
-          fun t ->
-            fun ctx ->
-              record ctx "rank" 2
-                (fun ctx ->
-                   let* () =
-                     field ctx "rank_scores" ((s (list string)) t.rank_scores)
-                    in
-                   let* () = field ctx "rank_name" (string t.rank_name)
-                    in Ok ())
+          fun t ctx ->
+            record ctx "rank" 2
+              (fun ctx ->
+                 let* () =
+                   field ctx "rank_scores" ((s (list string)) t.rank_scores)
+                  in
+                 let* () = field ctx "rank_name" (string t.rank_name)
+                  in Ok ())
       let _ = serialize_rank
       open! Serde
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let deserialize_rank =
-        let ( let* ) = Result.bind in
+        let ( let* ) = Stdlib.Result.bind in
         let _ = ( let* ) in
         let open Serde.De in
           fun ctx ->
@@ -153,13 +151,13 @@
                  let* () = read_fields ()
                   in
                  let* rank_scores =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg
                               "missing field \"rank_scores\" (\"rank_scores\")")
                      (!rank_scores)
                   in
                  let* rank_name =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"rank_name\" (\"rank_name\")")
                      (!rank_name)
                   in Ok { rank_name; rank_scores })
@@ -179,36 +177,32 @@
   include
     struct
       let _ = fun (_ : t) -> ()
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let serialize_t =
+        let ( let* ) = Stdlib.Result.bind in
+        let _ = ( let* ) in
         let open Serde.Ser in
-          fun t ->
-            fun ctx ->
-              record ctx "t" 8
-                (fun ctx ->
-                   let* () = field ctx "name" (string t.name)
-                    in
-                   let* () = field ctx "commisioned" (bool t.commisioned)
-                    in
-                   let* () = field ctx "updated_at" (int64 t.updated_at)
-                    in
-                   let* () = field ctx "credits" ((s (option int32)) t.credits)
-                    in
-                   let* () =
-                     field ctx "keywords" ((s (array string)) t.keywords)
-                    in
-                   let* () = field ctx "rank" ((s serialize_rank) t.rank)
-                    in
-                   let* () = field ctx "value" (float t.value)
-                    in let* () = field ctx "type" (string t.type_)
-                        in Ok ())
+          fun t ctx ->
+            record ctx "t" 8
+              (fun ctx ->
+                 let* () = field ctx "name" (string t.name)
+                  in
+                 let* () = field ctx "commisioned" (bool t.commisioned)
+                  in
+                 let* () = field ctx "updated_at" (int64 t.updated_at)
+                  in
+                 let* () = field ctx "credits" ((s (option int32)) t.credits)
+                  in
+                 let* () = field ctx "keywords" ((s (array string)) t.keywords)
+                  in
+                 let* () = field ctx "rank" ((s serialize_rank) t.rank)
+                  in
+                 let* () = field ctx "value" (float t.value)
+                  in let* () = field ctx "type" (string t.type_)
+                      in Ok ())
       let _ = serialize_t
       open! Serde
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let deserialize_t =
-        let ( let* ) = Result.bind in
+        let ( let* ) = Stdlib.Result.bind in
         let _ = ( let* ) in
         let open Serde.De in
           fun ctx ->
@@ -281,18 +275,18 @@
                  let* () = read_fields ()
                   in
                  let* name =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"name\" (\"name\")") (
                      !name)
                   in
                  let* commisioned =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg
                               "missing field \"commisioned\" (\"commisioned\")")
                      (!commisioned)
                   in
                  let* updated_at =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg
                               "missing field \"updated_at\" (\"updated_at\")")
                      (!updated_at)
@@ -300,22 +294,22 @@
                  let credits =
                    match !credits with | Some opt -> opt | None -> None in
                  let* keywords =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"keywords\" (\"keywords\")")
                      (!keywords)
                   in
                  let* rank =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"rank\" (\"rank\")") (
                      !rank)
                   in
                  let* value =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"value\" (\"value\")")
                      (!value)
                   in
                  let* type_ =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"type\" (\"type_\")") (
                      !type_)
                   in
@@ -337,23 +331,20 @@
   include
     struct
       let _ = fun (_ : t_list) -> ()
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let serialize_t_list =
+        let ( let* ) = Stdlib.Result.bind in
+        let _ = ( let* ) in
         let open Serde.Ser in
-          fun t ->
-            fun ctx ->
-              record ctx "t_list" 1
-                (fun ctx ->
-                   let* () =
-                     field ctx "stuff" ((s (list (s serialize_t))) t.stuff)
-                    in Ok ())
+          fun t ctx ->
+            record ctx "t_list" 1
+              (fun ctx ->
+                 let* () =
+                   field ctx "stuff" ((s (list (s serialize_t))) t.stuff)
+                  in Ok ())
       let _ = serialize_t_list
       open! Serde
-      let ( let* ) = Result.bind
-      let _ = ( let* )
       let deserialize_t_list =
-        let ( let* ) = Result.bind in
+        let ( let* ) = Stdlib.Result.bind in
         let _ = ( let* ) in
         let open Serde.De in
           fun ctx ->
@@ -382,7 +373,7 @@
                  let* () = read_fields ()
                   in
                  let* stuff =
-                   Option.to_result
+                   Stdlib.Option.to_result
                      ~none:(`Msg "missing field \"stuff\" (\"stuff\")")
                      (!stuff)
                   in Ok { stuff })

--- a/derive/variants.t/variant_adjacently_tagged_test.ml
+++ b/derive/variants.t/variant_adjacently_tagged_test.ml
@@ -1,11 +1,9 @@
-[@@@warning "-37"]
-
 type rank =
   | Captain of { name : string; ship : string }
   | Commander of string * int32 * float
   | Lt of bool option
   | Ensign
-[@@deriving serialize, deserialize] [@@serde {tag = "t"; content = "c"}]
+[@@deriving serialize, deserialize] [@@serde { tag = "t"; content = "c" }]
 
 type ranks = Ranks of rank list [@@deriving serialize, deserialize]
 

--- a/derive/variants.t/variant_externally_tagged_test.ml
+++ b/derive/variants.t/variant_externally_tagged_test.ml
@@ -1,5 +1,3 @@
-[@@@warning "-37"]
-
 type rank =
   | Captain of { name : string; ship : string }
   | Commander of string * int32 * float

--- a/derive/variants.t/variant_internally_tagged_test.ml
+++ b/derive/variants.t/variant_internally_tagged_test.ml
@@ -1,11 +1,9 @@
-[@@@warning "-37"]
-
 type rank =
   | Captain of { name : string; ship : string }
   | Commander of string * int32 * float
   | Lt of bool option
   | Ensign
-[@@deriving serialize, deserialize] [@@serde {tag = "t"}]
+[@@deriving serialize, deserialize] [@@serde { tag = "t" }]
 
 type ranks = Ranks of rank list [@@deriving serialize, deserialize]
 


### PR DESCRIPTION
Hi! I had a look at the test failures and they seemed to be mostly just formatting differences and nothing implementation related so I went ahead and promoted the changes.

Two stylistic changes were responsible for the bulk of the changes:
- `fun x -> fun y -> x + y` became `fun x y -> x + y`
- `Result` and `Option` were specified as `Stdlib.Result` and `Stdlib.Option`

One strange thing: the tests were throwing errors that `[@@@warning "-37"]` wasn't allowed to appear at that location. I'm not sure this is true, but removing it resolved those errors and didn't introduce any new errors.
There were some regressions in the compiler regarding top-level placement of attributes: https://github.com/ocaml/ocaml/pull/13170 but I couldn't tell if they were already implemented in 5.2. In any case, should those errors re-appear in a new release we can just add back those attributes. (Or maybe put it in a `dune` file? See https://stackoverflow.com/a/57120928/16727853)

I'm not familiar with serde's codebase so I hope I didn't miss anything, but I think most changes were pretty straightforward.